### PR TITLE
Testing producing/consuming messages

### DIFF
--- a/back_end/producer.py
+++ b/back_end/producer.py
@@ -11,10 +11,9 @@ print("hello, my name is {name}. {user} -> {password}".format(name=NAME,user=MSG
 print("---------------------------------------")
 
 
-#connection = pika.BlockingConnection(pika.ConnectionParameters(HOST,5672,'/',pika.PlainCredentials(
-#MSG_USER,MSG_PASS)))
+connection = pika.BlockingConnection(pika.ConnectionParameters(HOST,5672,'/',pika.PlainCredentials(MSG_USER,MSG_PASS)))
 
-connection = pika.BlockingConnection(pika.ConnectionParameters(HOST,"5672","/",pika.PlainCredentials("example","example")))
+#connection = pika.BlockingConnection(pika.ConnectionParameters(HOST,"5672","/",pika.PlainCredentials("example","example")))
 
 channel = connection.channel()
 

--- a/back_end/run.sh
+++ b/back_end/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-#exec python3 ./producer.py
-exec python3 ./consumer.py
+python3 ./producer.py
+python3 ./consumer.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - MSG_PASS=${MSG_PASS}
       - TEST=${TEST}
       - MESSAGING_HOST=messaging  
-      - PYTHONBUFFERED=1
+      - PYTHONUNBUFFERED=1
     command: ["./wait-for-it.sh","messaging:5672","-t","59","--","./run.sh"]
     depends_on:
       - messaging


### PR DESCRIPTION
Got it, turns out to be a couple of things: [exec's in your shell script](https://stackoverflow.com/questions/3877657/my-shell-script-stops-after-exec) and PYTHONUNBUFFERED as an env variable in docker-compose.yml.
I uncommented everything and it seems to be working fine:

```
ryan@R90VJ3MK:/tmp/IT490_TESTING$ docker-compose logs back-end
Attaching to it490_testing_back-end_1
back-end_1   | wait-for-it.sh: waiting 59 seconds for messaging:5672
back-end_1   | wait-for-it.sh: messaging:5672 is available after 7 seconds
back-end_1   | pika install
back-end_1   | hello, my name is . guest -> guest
back-end_1   | ---------------------------------------
back-end_1   | Consumer file------------------
back-end_1   | => waiting for messages. To exit press CTRL+C
back-end_1   |  [x] Received 'new message'
back-end_1   |  [x] Done
```
